### PR TITLE
chore: remove unneeded deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,14 +13,12 @@
     "test": "jest --runInBand"
   },
   "dependencies": {
-    "array-find-index": "^1.0.2",
     "create-react-class": "^15.7.0",
     "fbjs": "^3.0.0",
     "hyphenate-style-name": "^1.0.4",
     "inline-style-prefixer": "^6.0.0",
     "normalize-css-color": "^1.0.2",
-    "prop-types": "^15.6.0",
-    "yarn": "^1.22.17"
+    "prop-types": "^15.6.0"
   },
   "peerDependencies": {
     "react": ">=17.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1483,10 +1483,6 @@ array-equal@^1.0.0:
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
   integrity sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=
 
-array-find-index@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz"
-
 array-includes@^3.1.1, array-includes@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.2.tgz#a8db03e0b88c8c6aeddc49cb132f9bcab4ebf9c8"
@@ -5720,11 +5716,6 @@ yargs@^15.3.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
-
-yarn@^1.22.17:
-  version "1.22.17"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.17.tgz#bf910747d22497b573131f7341c0e1d15c74036c"
-  integrity sha512-H0p241BXaH0UN9IeH//RT82tl5PfNraVpSpEoW+ET7lmopNC61eZ+A+IDvU8FM6Go5vx162SncDL8J1ZjRBriQ==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
This PR removes two dependencies which were unnecessary and unused: `yarn` and `array-find-index`.

Closes [yarn task](https://app.asana.com/0/0/1201494315137077/f) and [array-find-index](https://app.asana.com/0/0/1201494315137078/f) tasks.

Tested by building and using the output in [Desktop branch](https://github.com/ExodusMovement/exodus-desktop/pull/11988)