### PR TITLE
revert: [fix] Encode URL in background-image CSS property

### DIFF
--- a/src/exports/Image/index.js
+++ b/src/exports/Image/index.js
@@ -129,10 +129,6 @@ function resolveAssetUri(source): ?string {
     }
   }
 
-  if (uri && uri.includes('"')) {
-    throw new Error('Provided uri contains double quote.');
-  }
-
   return uri;
 }
 
@@ -198,6 +194,9 @@ const Image: React.AbstractComponent<ImageProps, React.ElementRef<typeof View>> 
     const selectedSource = shouldDisplaySource ? source : defaultSource;
     const displayImageUri = resolveAssetUri(selectedSource);
     const imageSizeStyle = resolveAssetDimensions(selectedSource);
+    if (displayImageUri && displayImageUri.includes('"')) {
+      throw new Error('Provided uri contains double quote.');
+    }
     const backgroundImage = displayImageUri ? `url("${displayImageUri}")` : null;
     const backgroundSize = getBackgroundSize();
 

--- a/src/exports/Image/index.js
+++ b/src/exports/Image/index.js
@@ -129,6 +129,10 @@ function resolveAssetUri(source): ?string {
     }
   }
 
+  if (uri && uri.includes('"')) {
+    throw new Error('Provided uri contains double quote.');
+  }
+
   return uri;
 }
 

--- a/src/exports/Image/index.js
+++ b/src/exports/Image/index.js
@@ -194,7 +194,7 @@ const Image: React.AbstractComponent<ImageProps, React.ElementRef<typeof View>> 
     const selectedSource = shouldDisplaySource ? source : defaultSource;
     const displayImageUri = resolveAssetUri(selectedSource);
     const imageSizeStyle = resolveAssetDimensions(selectedSource);
-    const backgroundImage = displayImageUri ? `url("${encodeURI(displayImageUri)}")` : null;
+    const backgroundImage = displayImageUri ? `url("${displayImageUri}")` : null;
     const backgroundSize = getBackgroundSize();
 
     // Accessibility image allows users to trigger the browser's image context menu


### PR DESCRIPTION
This reverts commit 68c6f66838227950a1ce975793c1a2e004731b3e.

This fixes a bug where svg data uris were double encoded causing them to not render.